### PR TITLE
Update hover line values

### DIFF
--- a/src/app/graph/graph.service.ts
+++ b/src/app/graph/graph.service.ts
@@ -334,11 +334,17 @@ export class GraphService {
     const values = [];
     selectAll('.line').each(function (d: any) {
       const i = self.bisectX(d.data, currentX, 1);
-      const x0 = d.data[i - 1][self.settings.props.x];
-      const x1 = d.data[i][self.settings.props.x];
-      const closestIndex = (Math.abs(currentX - x0) > Math.abs(currentX - x1)) ? i : i - 1;
-      const boundedIndex = Math.min(d.data.length - 1, Math.max(0, closestIndex + offset));
-      values.push(self.getLineEventValue(d, boundedIndex, this));
+      if (d.data.length && d.data[i]) {
+        const x0 = d.data[i - 1][self.settings.props.x];
+        const x1 = d.data[i][self.settings.props.x];
+        const closestIndex = (Math.abs(currentX - x0) > Math.abs(currentX - x1)) ? i : i - 1;
+        const boundedIndex = Math.min(d.data.length - 1, Math.max(0, closestIndex + offset));
+        // Only push value if less than a full stop away from the closest
+        const val = self.getLineEventValue(d, boundedIndex, this);
+        if (Math.abs(currentX - val.x) < 1) {
+          values.push(val);
+        }
+      }
     });
     return values;
   }


### PR DESCRIPTION
Fixes https://github.com/EvictionLab/eviction-maps/issues/298. Adds a null check to avoid the errors for items without data, and only pushes values within 1 of the current x value (behavior shown below). The new behavior matters for https://github.com/EvictionLab/eviction-maps/issues/249

![hover](https://user-images.githubusercontent.com/8291663/34365584-d66947ea-ea5f-11e7-9a30-2d85e3a9fa45.gif)
