### PR TITLE
Sets min Y extent to 0

### DIFF
--- a/src/app/graph/graph.service.ts
+++ b/src/app/graph/graph.service.ts
@@ -606,6 +606,8 @@ export class GraphService {
     if (this.type === 'line') {
       const ranges = this.getRange();
       const extents = this.getExtent();
+      // Set min Y to at least 0
+      extents.y[0] = Math.max(0, extents.y[0]);
       // Cap Y extent to maxVal if present
       if (this.settings.axis.y.maxVal > 0) {
         extents.y[1] = Math.min(extents.y[1], this.settings.axis.y.maxVal);


### PR DESCRIPTION
Closes https://github.com/EvictionLab/eviction-maps/issues/1164 once pulled in there. `getExtent` was causing the wide ranges now that we have the upper end of the axis capped, so it's set to a minimum of 0 here.

<img width="1243" alt="screen shot 2018-04-30 at 9 02 35 am" src="https://user-images.githubusercontent.com/8291663/39431327-03ae8b86-4c56-11e8-93c5-17923249e38b.png">

<img width="1263" alt="screen shot 2018-04-30 at 9 09 25 am" src="https://user-images.githubusercontent.com/8291663/39431392-346379e4-4c56-11e8-9a45-e8c62e021cfa.png">
